### PR TITLE
Feature/header test

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
     "build": "tsc && vite build",
     "lint": "eslint src --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "test": "vitest run",
+    "test:dev": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@fontsource/nunito": "^5.0.15",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,13 +1,14 @@
 sonar.projectKey=caminolosada_Rick-Morty-
 sonar.organization=caminolosada
 
-# This is the name and version displayed in the SonarCloud UI.
-#sonar.projectName=Rick-Morty-
-#sonar.projectVersion=1.0
-
-
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
-#sonar.sources=.
+sonar.sources=./src
 
 # Encoding of the source code. Default is default system encoding
-#sonar.sourceEncoding=UTF-8
+sonar.sourceEncoding=UTF-8
+
+sonar.test.inclusions=src/**/*.test.ts, src/**/*.test.tsx
+
+sonar.coverage.exclusions=**/types.ts, **/*.d.ts, src/styles/GlobalStyle, src/main.tsx, src/routers/lazyComponents.tsx
+
+sonar.javascript.lcov.reportPaths=coverage/lcov.info

--- a/src/components/Header/Header.test.tsx
+++ b/src/components/Header/Header.test.tsx
@@ -1,0 +1,17 @@
+import { screen } from "@testing-library/react";
+import { renderWithProviders, wrapWithRouter } from "../../utils/testUtils";
+import Header from "./Header";
+
+describe("Given a Header component", () => {
+  describe("When it is rendered", () => {
+    test("Then it should show the Rick&Morty's logo with the alternative text 'rick and morty logo'", () => {
+      renderWithProviders(wrapWithRouter(<Header />));
+
+      const expectedAlternativeText = "rick and morty logo";
+
+      const rickMortyLogo = screen.getByAltText(expectedAlternativeText);
+
+      expect(rickMortyLogo).toBeInTheDocument();
+    });
+  });
+});

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,6 +1,9 @@
-import { PreloadedState } from "@reduxjs/toolkit";
-import { combineReducers } from "@reduxjs/toolkit";
-import { configureStore } from "@reduxjs/toolkit";
+import {
+  PreloadedState,
+  combineReducers,
+  configureStore,
+} from "@reduxjs/toolkit";
+
 import { TypedUseSelectorHook, useDispatch, useSelector } from "react-redux";
 
 const rootReducer = combineReducers({

--- a/src/utils/testUtils.tsx
+++ b/src/utils/testUtils.tsx
@@ -1,0 +1,40 @@
+import { PreloadedState } from "@reduxjs/toolkit";
+import { RootState, setupStore, store } from "../store";
+import { PropsWithChildren } from "react";
+import { render } from "@testing-library/react";
+import { ThemeProvider } from "styled-components";
+import theme from "../styles/theme";
+import GlobalStyle from "../styles/GlobalStyle/GlobalStyle";
+import { Provider } from "react-redux";
+import { createMemoryRouter, RouterProvider } from "react-router-dom";
+
+export const renderWithProviders = (
+  ui: React.ReactElement,
+  preloadedState?: PreloadedState<RootState>
+) => {
+  const testStore = preloadedState ? setupStore(preloadedState) : store;
+
+  const Wrapper = ({ children }: PropsWithChildren): React.ReactElement => {
+    return (
+      <ThemeProvider theme={theme}>
+        <GlobalStyle />
+        <Provider store={testStore}>{children}</Provider>
+      </ThemeProvider>
+    );
+  };
+
+  render(ui, { wrapper: Wrapper });
+};
+
+export const wrapWithRouter = (ui: React.ReactElement) => {
+  const routes = [
+    {
+      path: "/",
+      element: ui,
+    },
+  ];
+
+  const router = createMemoryRouter(routes);
+
+  return <RouterProvider router={router} />;
+};


### PR DESCRIPTION
- Añadido el archivo testUtils, que recoge tanto la herramienta renderWithProviders como wrapWithRouter, que ayudarán a ubicar de forma más adecuada los contextos necesarios para llevar a cabo los test.
- Añadido caso de uso de renderización para testear el componente Header