### PR TITLE
Add Layout.test with the use case of Header renderization

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -4,7 +4,7 @@ const Header = (): React.ReactElement => {
   return (
     <HeaderStyled>
       <img
-        src="/public/images/rick-morty-logo.svg"
+        src="/images/rick-morty-logo.svg"
         alt="rick and morty logo"
         width={262}
         height={63.84}

--- a/src/components/Layout/Layout.test.tsx
+++ b/src/components/Layout/Layout.test.tsx
@@ -1,0 +1,18 @@
+import { screen } from "@testing-library/react";
+import { renderWithProviders, wrapWithRouter } from "../../utils/testUtils";
+import Layout from "./Layout";
+
+describe("Given a Layout component", () => {
+  describe("When it is rendered", () => {
+    test("Then it should show the Rick&Morty's logo with the alternative text 'rick and morty logo'", () => {
+      renderWithProviders(wrapWithRouter(<Layout />));
+
+      const expectedAlternativeText = "rick and morty logo";
+
+      const rickMortyLogo = screen.getByRole("img", {
+        name: expectedAlternativeText,
+      });
+      expect(rickMortyLogo).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
- Añadido la suite de test Layout.test con caso de uso que corresponde a la correcta renderización del componente header.
- Se repara el path correspondiente a la imagen renderizada en Header